### PR TITLE
Fixed Python 3 version check to also work for Python 3.0

### DIFF
--- a/jsonquery.py
+++ b/jsonquery.py
@@ -5,7 +5,7 @@ import sqlalchemy
 
 PYTHON_VERSION = sys.version_info
 
-if PYTHON_VERSION > (3, 0, 0):  # pragma: no cover
+if PYTHON_VERSION >= (3,):  # pragma: no cover
     # PYTHON 3k: strings == unicode
     is_string = lambda s: isinstance(s, str)
 else:  # pragma: no cover


### PR DESCRIPTION
Very minor change but this fixes the Python 3 version check to also work for Python 3.0.